### PR TITLE
Addressing Infinite Loop issue 

### DIFF
--- a/src/Sentry.Unity.Editor/ConfigurationWindow/SentryWindow.cs
+++ b/src/Sentry.Unity.Editor/ConfigurationWindow/SentryWindow.cs
@@ -223,8 +223,6 @@ namespace Sentry.Unity.Editor.ConfigurationWindow
                 using var resourceStream =
                     GetType().Assembly.GetManifestResourceStream("Sentry.Unity.Editor.Resources.link.xml");
                 resourceStream.CopyTo(fileStream);
-
-                AssetDatabase.ImportAsset(LinkXmlPath);
             }
         }
 


### PR DESCRIPTION
It appears to be unncessary to call the AssetDatabase.Import on the XML file as its only used when building the end binary. By removing this call to Import the asset, it hopefully address the infinite loop issue that occurs on a clean project when first loading SentryWindow.cs. However, I say hopefully as I cannot verify that this fix address the infinite loop import as I don't know how to build the managed dlls for the SentryWindow.cs.